### PR TITLE
Refactor tools and fix pydantic warning

### DIFF
--- a/src/tidewave/tools/base.py
+++ b/src/tidewave/tools/base.py
@@ -5,7 +5,7 @@ Base MCP Tool functionality
 import inspect
 from typing import Any, Callable, get_type_hints
 
-from pydantic import ValidationError, create_model
+from pydantic import ValidationError, create_model, Field
 
 
 class MCPTool:
@@ -37,6 +37,9 @@ class MCPTool:
         sig = inspect.signature(self.func)
         type_hints = get_type_hints(self.func)
 
+        # Reserved field names that shadow BaseModel attributes
+        reserved_names = {"json"}
+
         fields = {}
         for param_name, param in sig.parameters.items():
             # For hidden parameters, ensure they have defaults
@@ -56,11 +59,25 @@ class MCPTool:
 
             param_type = type_hints[param_name]
 
+            # Handle field aliasing for reserved names
+            field_name = param_name
+            if param_name in reserved_names:
+                field_name = f"alias_{param_name}"
+
             # Handle default values
             if param.default == inspect.Parameter.empty:
-                fields[param_name] = (param_type, ...)
+                if param_name in reserved_names:
+                    fields[field_name] = (param_type, Field(alias=param_name))
+                else:
+                    fields[field_name] = (param_type, ...)
             else:
-                fields[param_name] = (param_type, param.default)
+                if param_name in reserved_names:
+                    fields[field_name] = (
+                        param_type,
+                        Field(default=param.default, alias=param_name),
+                    )
+                else:
+                    fields[field_name] = (param_type, param.default)
 
         return create_model(f"{self.name}_model", **fields)
 
@@ -97,11 +114,14 @@ class MCPTool:
     def validate_and_call(self, args: dict[str, Any]) -> dict[str, Any]:
         """Validate arguments using the shared pydantic model and call the function"""
         try:
-            # Validate input using the shared model
+            # Validate input using the shared model (uses aliases for validation)
             validated_args = self.model(**args)
 
-            # Call function with validated arguments
-            result = self.func(**validated_args.model_dump())
+            # Get the dumped data with aliases (by_alias=True ensures we get original field names)
+            dumped_args = validated_args.model_dump(by_alias=True)
+
+            # Call function with validated arguments using original field names
+            result = self.func(**dumped_args)
 
             # Format result for MCP
             return {"content": [{"type": "text", "text": str(result)}]}

--- a/src/tidewave/tools/base.py
+++ b/src/tidewave/tools/base.py
@@ -5,7 +5,7 @@ Base MCP Tool functionality
 import inspect
 from typing import Any, Callable, get_type_hints
 
-from pydantic import ValidationError, create_model, Field
+from pydantic import Field, ValidationError, create_model
 
 
 class MCPTool:
@@ -59,25 +59,19 @@ class MCPTool:
 
             param_type = type_hints[param_name]
 
-            # Handle field aliasing for reserved names
-            field_name = param_name
-            if param_name in reserved_names:
-                field_name = f"alias_{param_name}"
-
-            # Handle default values
             if param.default == inspect.Parameter.empty:
                 if param_name in reserved_names:
-                    fields[field_name] = (param_type, Field(alias=param_name))
+                    fields[f"alias_{param_name}"] = (param_type, Field(alias=param_name))
                 else:
-                    fields[field_name] = (param_type, ...)
+                    fields[param_name] = (param_type, ...)
             else:
                 if param_name in reserved_names:
-                    fields[field_name] = (
+                    fields[f"alias_{param_name}"] = (
                         param_type,
                         Field(default=param.default, alias=param_name),
                     )
                 else:
-                    fields[field_name] = (param_type, param.default)
+                    fields[param_name] = (param_type, param.default)
 
         return create_model(f"{self.name}_model", **fields)
 


### PR DESCRIPTION
The warning is:

        tidewave_python/.venv/lib/python3.13/site-packages/pydantic/_internal/_fields.py:198: UserWarning: Field name "json" in "project_eval_model" shadows an attribute in parent "BaseModel"