### PR TITLE
Support SQLAlchemy 1.3+ in execute_sql_query

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Issues = "https://github.com/tidewave-ai/tidewave_python/issues"
 [project.optional-dependencies]
 django = [ "django>=4.2" ]
 flask = [ "flask>=2" ]
-sqlalchemy = [ "sqlalchemy>=2.0" ]
+sqlalchemy = [ "sqlalchemy>=1.3" ]
 fastapi = [ "fastapi>=0.100", "a2wsgi>=1.9.0" ]
 
 [dependency-groups]

--- a/src/tidewave/sqlalchemy/sql.py
+++ b/src/tidewave/sqlalchemy/sql.py
@@ -29,14 +29,19 @@ def execute_sql_query(engine: Engine) -> Callable[[str, Optional[list[Any]]], st
         if arguments is None:
             arguments = []
 
-        with engine.connect() as connection:
-            if arguments:
-                result = connection.exec_driver_sql(query, tuple(arguments))
+        with engine.begin() as connection:
+            if hasattr(connection, "exec_driver_sql"):
+                # SQLAlchemy 1.4+ provides exec_driver_sql for raw driver SQL
+                if arguments:
+                    result = connection.exec_driver_sql(query, tuple(arguments))
+                else:
+                    result = connection.exec_driver_sql(query)
             else:
-                result = connection.exec_driver_sql(query)
-
-            # Commit the transaction for data persistence
-            connection.commit()
+                # SQLAlchemy 1.3 accepts raw SQL strings via execute()
+                if arguments:
+                    result = connection.execute(query, arguments)
+                else:
+                    result = connection.execute(query)
 
             # Check if this query returns data
             if result.returns_rows:


### PR DESCRIPTION
## Summary

- Lower the SQLAlchemy optional dependency from `>=2.0` to `>=1.3`
- `execute_sql_query` now works with SQLAlchemy 1.3, 1.4, and 2.0+
- `get_models` required no changes (already compatible)

## Changes

The SQL execution tool previously required SQLAlchemy 2.0+ due to:
1. `connection.exec_driver_sql()` — introduced in 1.4, unavailable in 1.3
2. `connection.commit()` — required by v2's autobegin model, unavailable on v1.3 connections

Fix:
- Use `engine.begin()` context manager for transaction management (auto-commits on success, works in all versions from 1.3+)
- Detect `exec_driver_sql` availability via `hasattr()` at runtime; fall back to `connection.execute()` with raw strings for v1.3

APIs used for results (`returns_rows`, `keys()`, `fetchall()`) are available in all versions from 1.3 onwards. The `get_models` tool uses only standard ORM introspection APIs (`__table__`, `__abstract__`, `__subclasses__()`) which are unchanged across versions.

## Motivation

Projects on SQLAlchemy 1.3/1.4 — including those with large codebases where upgrading to v2 is non-trivial — can now use the `execute_sql_query` and `get_models` tools.

## Test plan

- All 6 existing `test_sqlalchemy_execute_sql_query` tests pass against SQLAlchemy 2.0.48
- All 5 existing `test_sqlalchemy_get_models` tests pass against SQLAlchemy 2.0.48
- All 3 `test_fastapi` tests pass (including `test_with_sqlalchemy`)
- Manually verified against a running FastAPI app with SQLAlchemy 1.3.16 (PostgreSQL) — both `execute_sql_query` and `get_models` work correctly